### PR TITLE
add dependencies and change fcu_url in apm.launch

### DIFF
--- a/launch/apm.launch
+++ b/launch/apm.launch
@@ -2,7 +2,7 @@
 	<!-- vim: set ft=xml noet : -->
 	<!-- example launch script for ArduPilot based FCU's -->
 
-	<arg name="fcu_url" default="udp://127.0.0.1:14551@14550" />
+	<arg name="fcu_url" default="udp://:14551@" />
 	<!-- <arg name="fcu_url" default="udp://127.0.0.1:14561@" /> -->               <!-- remove comment for rover -->
 	
 	<arg name="gcs_url" default="" />

--- a/package.xml
+++ b/package.xml
@@ -56,6 +56,8 @@
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>mavros</exec_depend>
+  <exec_depend>cartographer_ros</exec_depend>
+  <exec_depend>robot_pose_publisher</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -55,6 +55,7 @@
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>mavros</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
Added a dependency for mavros, this is added as an exec_depend since its only needed for runtime. If you have other dependencies to packages that are needed during build for example you need to add them to the correct part of the packages.xml file. 
I also changed the apm.launch file to use the udp port 14551 since SITL creates that by default. The line you had was incorrect and giving errors on launch. The way it is written is equivalent to udp://0.0.0.0:14551 which binds the udp port to the local host on port 14551.